### PR TITLE
add support for IPv6 and EU servers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,4 +30,4 @@ const MIXPANEL_PROPERTIES = [
 
 // API changes based on the PR from @aonic - https://github.com/nithincvpoyyil/mixpanel-tools/pull/3
 
-const MIXPANEL_API_PATTERN = /\/\/(api|api\-js)\.mixpanel\.com\/(track|engage)/i;
+const MIXPANEL_API_PATTERN = /\/\/(ipv6-)?(api)(-js)?(-eu)?\.mixpanel\.com\/(track|engage)/i;


### PR DESCRIPTION
Fixes #17 adding support for `EU` servers as well as `IPV6` servers

Regex tester: https://regexr.com/5k9k2